### PR TITLE
Update headline scale and use same line-height for all sizes

### DIFF
--- a/lib/repetitivo/config/typography.scss
+++ b/lib/repetitivo/config/typography.scss
@@ -22,42 +22,19 @@ $heading-font-weight--light: 300 !default;
 $heading-font-weight--bold: 700 !default;
 
 $font-sizes: () !default;
+$default-font-sizes: ();
 
-$default-font-sizes: (
-  deca: (
-    default: (
-      font-size: modular-scale(1, $base-font-size, $heading-scale),
-      line-height: $heading-line-height
+@for $i from 1 through length($heading-sizes) {
+  $heading-size: nth($heading-sizes, $i);
+
+  $default-font-sizes: map-merge($default-font-sizes, (
+    $heading-size: (
+      default: (font-size: modular-scale($i, $base-font-size, $scale-minor-second)),
+      xs:      (font-size: modular-scale($i, $base-font-size, $scale-major-second)),
+      s:       (font-size: modular-scale($i, $base-font-size, $scale-minor-third)),
+      m:       (font-size: modular-scale($i, $base-font-size, $scale-major-third)),
+      l:       (font-size: modular-scale($i, $base-font-size, $scale-perfect-fourth)),
+      xl:      (font-size: modular-scale($i, $base-font-size, $scale-augmented-fourth))
     )
-  ),
-  hecto: (
-    default: (
-      font-size: modular-scale(2, $base-font-size, $heading-scale),
-      line-height: $heading-line-height
-    )
-  ),
-  kilo: (
-    default: (
-      font-size: modular-scale(3, $base-font-size, $heading-scale),
-      line-height: $heading-line-height
-    )
-  ),
-  mega: (
-    default: (
-      font-size: modular-scale(4, $base-font-size, $heading-scale),
-      line-height: $heading-line-height
-    )
-  ),
-  giga: (
-    default: (
-      font-size: modular-scale(5, $base-font-size, $heading-scale),
-      line-height: $heading-line-height
-    )
-  ),
-  tera: (
-    default: (
-      font-size: modular-scale(6, $base-font-size, $heading-scale),
-      line-height: $heading-line-height
-    )
-  )
-);
+  ));
+}

--- a/lib/repetitivo/patterns/typography.scss
+++ b/lib/repetitivo/patterns/typography.scss
@@ -12,6 +12,8 @@
     font-family: $heading-font-family;
     font-feature-settings: $heading-font-feature-settings;
     font-weight: $heading-font-weight;
+
+    line-height: $heading-line-height;
   }
 
   %heading-font--light {


### PR DESCRIPTION
Use modular-scale for headlines. Output:

```
.Heading--deca {
  font-size: 19px; }
  @media screen and (min-width: 25em) {
    .Heading--deca {
      font-size: 20px; } }
  @media screen and (min-width: 37.5em) {
    .Heading--deca {
      font-size: 22px; } }
  @media screen and (min-width: 50em) {
    .Heading--deca {
      font-size: 23px; } }
  @media screen and (min-width: 62.5em) {
    .Heading--deca {
      font-size: 24px; } }
  @media screen and (min-width: 75em) {
    .Heading--deca {
      font-size: 25px; } }
```

Readable scss: not very
Works like magic: yes

Possible to override from a project like this:

```
$font-sizes: (
  tera: (
    xl: (
      font-size: 200px
    )
  )
);
```
